### PR TITLE
Fixed constructor signature

### DIFF
--- a/example/index.adoc
+++ b/example/index.adoc
@@ -262,8 +262,8 @@ initializing the corresponding fields:
 public FlightListBapi(String fromCountryKey,
                         String fromCity,
                         String toCountryKey,
-                        String airlineCarrier,
                         String toCity,
+                        String airlineCarrier,
                         boolean afternoon,
                         int maxRead) {
 


### PR DESCRIPTION
Parameter order updated according to later call to constructor: airlineCarrier must be obviously AFTER toCity.
